### PR TITLE
Dependency cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/icons",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Px Blue icons",
   "main": "./iconfont/index.css",
   "repository": {

--- a/progress/angular/dist/ng-progress-icons/fesm5/pxblue-ng-progress-icons.js
+++ b/progress/angular/dist/ng-progress-icons/fesm5/pxblue-ng-progress-icons.js
@@ -1,4 +1,4 @@
-import { Injectable, NgModule, Component, defineInjectable } from '@angular/core';
+import { Injectable, Component, NgModule, defineInjectable } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 /**

--- a/progress/angular/dist/ng-progress-icons/package.json
+++ b/progress/angular/dist/ng-progress-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/ng-progress-icons",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Angular progress icons for PX Blue applications",
   "main": "bundles/pxblue-ng-progress-icons.umd.js",
   "dependencies": {

--- a/progress/angular/dist/ng-progress-icons/package.json
+++ b/progress/angular/dist/ng-progress-icons/package.json
@@ -8,8 +8,8 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+    "@angular/common": ">=6.0.0",
+    "@angular/core": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/progress/angular/projects/ng-progress-icons/package.json
+++ b/progress/angular/projects/ng-progress-icons/package.json
@@ -3,13 +3,12 @@
   "version": "1.1.2",
   "description": "Angular progress icons for PX Blue applications",
   "main": "bundles/pxblue-ng-progress-icons.umd.js",
-  "dependencies": {
+  "devDependencies": {
     "tslib": "^1.9.0"
   },
-  "devDependencies": {},
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+    "@angular/common": ">=6.0.0",
+    "@angular/core": ">=6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Get rid of the peerDependency mismatch warning when using Angular version > 6