### PR TITLE
Add background color attr to progress icons

### DIFF
--- a/progress/angular/CHANGELOG.md
+++ b/progress/angular/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## v1.2.0
+## v1.2.0 (to be published)
 
 -   Added UPS progress icon (`<ups-progress>`)
+-   Added the option to show label percentages, with the following attributes: `showPercentLabel`, `labelColor`, `labelPosition`, `labelSize` and
+-   Added an optional `backgroundColor` attribute to display a background in the unfilled area
 
 ## v1.1.3
 

--- a/progress/angular/README.md
+++ b/progress/angular/README.md
@@ -41,7 +41,7 @@ imports: [
 <battery-progress percent="80" size="36" color="green" [charging]="true" [outlined]="true"></battery-progress>
 <heart-progress percent="99" size="36" color="pink" [outlined]="true"></heart-progress>
 <pie-progress percent="30" size="36" color="#0000ff" ring="4" [outlined]="true"></pie-progress>
-<ups-progress percent="10" size="36" color="#0000ff" [outlined]="true"></ups-progress>
+<ups-progress percent="10" size="36" color="#0000ff" [outlined]="true" backgroundColor="white"></ups-progress>
 ```
 
 ## API
@@ -52,16 +52,17 @@ These props are available on all of the progress icons in this package.
 
 <div style="overflow: auto;">
 
-| @Input           | Description                         | Type                                  | Required | Default        |
-| ---------------- | ----------------------------------- | ------------------------------------- | -------- | -------------- |
-| percent          | The amount to fill the icon (0-100) | `number`                              | no       | 100            |
-| size             | The size of the icon (in px)        | `number`                              | no       | 24             |
-| outlined         | Whether to use the outlined style   | `boolean`                             | no       | false          |
-| color            | The color used for the icon fill    | `string`                              | no       | 'currentColor' |
-| showPercentLabel | Option to show percentage overlay   | `boolean`                             | no       | false          |
-| labelColor       | Label text color                    | `string`                              | no       |                |
-| labelPosition    | Where to display the text label     | `top, bottom, center, right, left`    | no       | `center`       |
-| labelSize        | Size of the label in px             | `number`                              | no       | `size/4`       |
+| @Input           | Description                            | Type                               | Required | Default        |
+| ---------------- | -------------------------------------- | ---------------------------------- | -------- | -------------- |
+| percent          | The amount to fill the icon (0-100)    | `number`                           | no       | 100            |
+| size             | The size of the icon (in px)           | `number`                           | no       | 24             |
+| outlined         | Whether to use the outlined style      | `boolean`                          | no       | false          |
+| color            | The color used for the icon fill       | `string`                           | no       | 'currentColor' |
+| showPercentLabel | Option to show percentage overlay      | `boolean`                          | no       | false          |
+| labelColor       | Label text color                       | `string`                           | no       |                |
+| labelPosition    | Where to display the text label        | `top, bottom, center, right, left` | no       | `center`       |
+| labelSize        | Size of the label in px                | `number`                           | no       | `size/4`       |
+| backgroundColor  | Background color for the unfilled area | `string`                           | no       |                |
 
 </div>
 
@@ -71,17 +72,17 @@ Any other props supplied will be provided to the root element (`svg`).
 
 The battery supports all of the shared attributes above and the following additional attribute:
 
-| @Input    | Description                            | Type      | Required | Default |
-| --------- | -------------------------------------- | --------- | -------- | ------- |
-| charging  | Whether to show the charging indicator | `boolean` | no       | false   |
+| @Input   | Description                            | Type      | Required | Default |
+| -------- | -------------------------------------- | --------- | -------- | ------- |
+| charging | Whether to show the charging indicator | `boolean` | no       | false   |
 
 ### Pie Attributes
 
 The pie supports all of the shared attributes above and the following additional attribute:
 
-| @Input    | Description                                                        | Type     | Required | Default |
-| --------- | ------------------------------------------------------------------ | -------- | -------- | ------- |
-| ring      | The thickness of the outer ring (1 = thin ring, 10 = full circle ) | `number` | no       | 10      |
+| @Input | Description                                                        | Type     | Required | Default |
+| ------ | ------------------------------------------------------------------ | -------- | -------- | ------- |
+| ring   | The thickness of the outer ring (1 = thin ring, 10 = full circle ) | `number` | no       | 10      |
 
 ## Building & Packaging
 

--- a/progress/angular/README.md
+++ b/progress/angular/README.md
@@ -54,15 +54,15 @@ These props are available on all of the progress icons in this package.
 
 | @Input           | Description                            | Type                               | Required | Default        |
 | ---------------- | -------------------------------------- | ---------------------------------- | -------- | -------------- |
-| percent          | The amount to fill the icon (0-100)    | `number`                           | no       | 100            |
-| size             | The size of the icon (in px)           | `number`                           | no       | 24             |
-| outlined         | Whether to use the outlined style      | `boolean`                          | no       | false          |
+| backgroundColor  | Background color for the unfilled area | `string`                           | no       |                |
 | color            | The color used for the icon fill       | `string`                           | no       | 'currentColor' |
-| showPercentLabel | Option to show percentage overlay      | `boolean`                          | no       | false          |
 | labelColor       | Label text color                       | `string`                           | no       |                |
 | labelPosition    | Where to display the text label        | `top, bottom, center, right, left` | no       | `center`       |
 | labelSize        | Size of the label in px                | `number`                           | no       | `size/4`       |
-| backgroundColor  | Background color for the unfilled area | `string`                           | no       |                |
+| outlined         | Whether to use the outlined style      | `boolean`                          | no       | false          |
+| percent          | The amount to fill the icon (0-100)    | `number`                           | no       | 100            |
+| showPercentLabel | Option to show percentage overlay      | `boolean`                          | no       | false          |
+| size             | The size of the icon (in px)           | `number`                           | no       | 24             |
 
 </div>
 

--- a/progress/angular/README.md
+++ b/progress/angular/README.md
@@ -41,7 +41,7 @@ imports: [
 <battery-progress percent="80" size="36" color="green" [charging]="true" [outlined]="true"></battery-progress>
 <heart-progress percent="99" size="36" color="pink" [outlined]="true"></heart-progress>
 <pie-progress percent="30" size="36" color="#0000ff" ring="4" [outlined]="true"></pie-progress>
-<ups-progress percent="10" size="36" color="#0000ff" [outlined]="true" backgroundColor="white"></ups-progress>
+<ups-progress percent="10" size="36" color="#0000ff" [outlined]="true"></ups-progress>
 ```
 
 ## API

--- a/progress/angular/components/src/lib/battery/battery.component.ts
+++ b/progress/angular/components/src/lib/battery/battery.component.ts
@@ -42,9 +42,10 @@ import { rangeValue } from '../utilities';
                         <path overflow="visible" [attr.d]="getClipPath()" />
                     </clipPath>
                 </defs>
+                <path *ngIf="outlined && backgroundColor" [attr.d]="basePath" [attr.fill]="backgroundColor" />
                 <path
-                    [attr.fill]="color || 'currentColor'"
-                    [attr.fill-opacity]="outlined || percent >= 100 ? '1' : '0.3'"
+                    [attr.fill]="(!outlined && backgroundColor) || color || 'currentColor'"
+                    [attr.fill-opacity]="outlined || percent >= 100 || (!outlined && backgroundColor) ? '1' : '0.3'"
                     [attr.clip-path]="'url(#' + getID() + ')'"
                     [attr.d]="getBasePath()"
                 />

--- a/progress/angular/components/src/lib/battery/battery.component.ts
+++ b/progress/angular/components/src/lib/battery/battery.component.ts
@@ -42,7 +42,7 @@ import { rangeValue } from '../utilities';
                         <path overflow="visible" [attr.d]="getClipPath()" />
                     </clipPath>
                 </defs>
-                <path *ngIf="outlined && backgroundColor" [attr.d]="basePath" [attr.fill]="backgroundColor" />
+                <path *ngIf="backgroundColor" [attr.d]="basePath" [attr.fill]="backgroundColor" />
                 <path
                     [attr.fill]="(!outlined && backgroundColor) || color || 'currentColor'"
                     [attr.fill-opacity]="outlined || percent >= 100 || (!outlined && backgroundColor) ? '1' : '0.3'"

--- a/progress/angular/components/src/lib/heart/heart.component.ts
+++ b/progress/angular/components/src/lib/heart/heart.component.ts
@@ -23,9 +23,10 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                 style="enable-background:new 0 0 24 24;"
                 xml:space="preserve"
             >
+                <path *ngIf="outlined && backgroundColor" [attr.d]="basePath" [attr.fill]="backgroundColor" />
                 <path
-                    [attr.fill]="color || 'currentColor'"
-                    [attr.fill-opacity]="outlined || percent >= 100 ? '1' : '0.3'"
+                    [attr.fill]="(!outlined && backgroundColor) || color || 'currentColor'"
+                    [attr.fill-opacity]="outlined || percent >= 100 || (!outlined && backgroundColor) ? '1' : '0.3'"
                     [attr.d]="getPath()"
                 />
                 <clipPath id="pxb-heart-clip">

--- a/progress/angular/components/src/lib/pie/pie.component.ts
+++ b/progress/angular/components/src/lib/pie/pie.component.ts
@@ -26,9 +26,15 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                     <path [attr.d]="clipPath" />
                 </clipPath>
                 <path
+                    *ngIf="outlined && backgroundColor"
+                    [attr.d]="twoToneBase"
                     [attr.clip-path]="'url(#pxb-donut-clip-' + stroke + ')'"
-                    [attr.fill]="color || 'currentColor'"
-                    [attr.fill-opacity]="outlined || percent >= 100 ? '1' : '0.3'"
+                    [attr.fill]="backgroundColor"
+                />
+                <path
+                    [attr.clip-path]="'url(#pxb-donut-clip-' + stroke + ')'"
+                    [attr.fill]="(!outlined && backgroundColor) || color || 'currentColor'"
+                    [attr.fill-opacity]="outlined || percent >= 100 || (!outlined && backgroundColor) ? '1' : '0.3'"
                     [attr.d]="outlined ? outlineBase : twoToneBase"
                 />
                 <path

--- a/progress/angular/components/src/lib/pxb-progress-icon.component.ts
+++ b/progress/angular/components/src/lib/pxb-progress-icon.component.ts
@@ -37,6 +37,7 @@ export class PxbProgressIconComponent implements OnChanges {
     @Input() color: string;
     @Input() labelColor: string;
     @Input() labelSize: number;
+    @Input() backgroundColor: string;
 
     inverted: boolean;
 

--- a/progress/angular/components/src/lib/ups/ups.component.ts
+++ b/progress/angular/components/src/lib/ups/ups.component.ts
@@ -24,12 +24,6 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                     </clipPath>
                 </defs>
 
-                <path
-                    opacity="0.3"
-                    d="M2 4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V6H19V8H22V11H19V13H22V16H19V18H22V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V18H5V16H2V13H5V11H2V8H5V6H2V4Z"
-                    [attr.fill]="color || 'currentColor'"
-                    *ngIf="!outlined"
-                />
                 <mask
                     id="mask-filled"
                     mask-type="alpha"
@@ -40,12 +34,14 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                     height="20"
                     *ngIf="!outlined"
                 >
-                    <path
-                        d="M2 4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V6H19V8H22V11H19V13H22V16H19V18H22V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V18H5V16H2V13H5V11H2V8H5V6H2V4Z"
-                        [attr.fill]="color || 'currentColor'"
-                    />
+                    <path [attr.d]="basePath" [attr.fill]="color || 'currentColor'" />
                 </mask>
                 <g mask="url(#mask-filled)" *ngIf="!outlined">
+                    <path
+                        opacity="backgroundColor ? 1: 0.3"
+                        [attr.d]="basePath"
+                        [attr.fill]="backgroundColor || color || 'currentColor'"
+                    />
                     <rect
                         x="2"
                         [attr.y]="startY"
@@ -56,6 +52,7 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                 </g>
 
                 <g [attr.fill]="color || 'currentColor'" *ngIf="outlined">
+                    <rect *ngIf="backgroundColor" x="4" y="4" width="16" height="16" [attr.fill]="backgroundColor" />
                     <path
                         fill-rule="evenodd"
                         d="M22 4C22 2.89543 21.1046 2 20 2H4C2.89543 2 2 2.89543 2 4V20C2 21.1046 2.89543 22 4 22H20C21.1046 22 22 21.1046 22 20V4ZM4 4V8H7V9H4V12H7V13H4V16H7V17H4V20H20V17H17V16H20V13H17V12H20V9H17V8H20V4H4Z"
@@ -86,6 +83,9 @@ export class UpsComponent extends PxbProgressIconComponent implements OnChanges 
     rangedPercent: number;
     startY: number;
     fillHeight: number;
+
+    basePath =
+        'M2 4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V6H19V8H22V11H19V13H22V16H19V18H22V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V18H5V16H2V13H5V11H2V8H5V6H2V4Z';
 
     ngOnChanges(): void {
         this.rangedPercent = rangeValue(this.percent, 0, 100);

--- a/progress/angular/components/src/lib/ups/ups.component.ts
+++ b/progress/angular/components/src/lib/ups/ups.component.ts
@@ -38,7 +38,7 @@ import { PxbProgressIconComponent } from '../pxb-progress-icon.component';
                 </mask>
                 <g mask="url(#mask-filled)" *ngIf="!outlined">
                     <path
-                        opacity="backgroundColor ? 1: 0.3"
+                        [attr.opacity]="backgroundColor ? 1 : 0.3"
                         [attr.d]="basePath"
                         [attr.fill]="backgroundColor || color || 'currentColor'"
                     />


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Partially addresses #75, need to do the same thing to React

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add background attr to the progress icons

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

outlined = false

![image](https://user-images.githubusercontent.com/8997218/92862662-fead4b00-f3c8-11ea-9ee9-2b1ed895e78d.png)

outlined = true 

![image](https://user-images.githubusercontent.com/8997218/92862730-108eee00-f3c9-11ea-8b8a-0e9fd80d4fcf.png)

backgroundColor = undefined

(same as before)