### PR TITLE
Bump version to trigger publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "build:rn-vector": "cd rn-vector && yarn build",
         "publish:package": "set npm_config_yes=true && npx -p @pxblue/publish pxb-publish",
         "tag:package": "set npm_config_yes=true && npx -p @pxblue/tag pxb-tag",
-        "start": "yarn build:font && cd mui && yarn start"
+        "start": "yarn build:font && open ./iconfont/PXBlueIcons.html && cd mui && yarn start"
     },
     "files": [
         "iconfont",


### PR DESCRIPTION
Bump @pxblue/icons version to `1.7.1-beta.1` to trigger an NPM publish. There was a bug that prevented the previous package from publishing